### PR TITLE
default org-file creation when in pdf-buffer

### DIFF
--- a/org-noter.el
+++ b/org-noter.el
@@ -1406,7 +1406,22 @@ when ARG < 0."
               t)
         (org-noter--create-session ast document-property notes-file-path))))
 
-  (when (and (not (eq major-mode 'org-mode)) (org-noter--valid-session org-noter--session))
+    (when (eq major-mode 'pdf-view-mode)
+    (setq pdfs-org-counterpart (concat (file-name-sans-extension buffer-file-name) ".org"))
+    (setq defaultname (file-name-sans-extension (buffer-name)))
+    (unless (file-exists-p pdfs-org-counterpart)
+      (progn
+	(let ((newheader (read-string "Header: " defaultname nil defaultname )))
+	  (setq orgnoter-init-string (concat "* " newheader "
+:PROPERTIES:
+:NOTER_DOCUMENT: " buffer-file-name "
+:END:"))
+	  (write-region orgnoter-init-string nil pdfs-org-counterpart))))
+    (delete-other-windows)
+    (find-file pdfs-org-counterpart)
+    (org-noter pdfs-org-counterpart))
+  
+  (when (and (not (eq major-mode 'org-mode)) (not (eq major-mode 'pdf-view-mode)) (org-noter--valid-session org-noter--session))
     (org-noter--setup-windows org-noter--session)
     (select-frame-set-input-focus (org-noter--session-frame org-noter--session))))
 


### PR DESCRIPTION
When in a pdf buffer, `org-noter` checks for an .org file in the same directory as the .pdf (with the same name before the extension), and switches to that file and calls `org-noter`; otherwise, an .org file is created in the same directory, user is prompted for a header title (defaults to the name of the pdf buffer) and the proper PROPERTIES are inserted into this header, the org-file is opened and `org-noter` is called.