### PR TITLE
add customization option to open note file of current session after kill session

### DIFF
--- a/org-noter.el
+++ b/org-noter.el
@@ -191,6 +191,11 @@ The title used will be the default one."
   :group 'org-noter
   :type 'boolean)
 
+(defcustom org-noter-open-note-file-after-kill-session nil
+  "If non-nil, note file of current session will be opened after kill the session."
+  :group 'org-noter
+  :type 'boolean)
+
 (defface org-noter-no-notes-exist-face
   '((t
      :foreground "chocolate"
@@ -1412,7 +1417,10 @@ want to kill."
             (progn
               (delete-other-windows)
               (set-frame-parameter nil 'name nil))
-          (delete-frame frame))))))
+          (delete-frame frame)))
+
+      (if org-noter-open-note-file-after-kill-session
+	  (find-file (org-noter--session-notes-file-path session))))))
 
 (defun org-noter-create-skeleton ()
   "Create notes skeleton with the PDF outline or annotations.


### PR DESCRIPTION
If we visit other buffers during we reading a `org-noter` session, the most recent buffer we visited will be open after we execute `org-noter-kill-session`.

However,  in some situations, we want to visit the note file even after kill session.

This pull request add a customization option to always open note file after `org-noter-kill-session`.