### PR TITLE
other-frame: customize option was quoted too much

### DIFF
--- a/org-noter.el
+++ b/org-noter.el
@@ -104,7 +104,7 @@ is member of `org-noter-notes-window-behavior' (which see)."
   :group 'org-noter
   :type '(choice (const :tag "Horizontal" horizontal-split)
                  (const :tag "Vertical" vertical-split)
-                 (const :tag "Other frame" 'other-frame)))
+                 (const :tag "Other frame" other-frame)))
 
 (define-obsolete-variable-alias 'org-noter-doc-split-percentage 'org-noter-doc-split-fraction "1.2.0")
 (defcustom org-noter-doc-split-fraction '(0.5 . 0.5)


### PR DESCRIPTION
In the description of the customization the other-frame option was quoted
one level too deep. This results in the variable having the value 'other-frame
instead of only other-frame.