### PR TITLE
Dedup pdf file names when searching for note files

### DIFF
--- a/org-noter.el
+++ b/org-noter.el
@@ -2146,7 +2146,7 @@ notes file, even if it finds one."
                                                  (file-name-directory (car notes-files)))))
             (setq notes-files-annotating notes-files)))
 
-        (when (> (length notes-files-annotating) 1)
+        (when (> (length (cl-delete-duplicates notes-files-annotating :test 'equal)) 1)
           (setq notes-files-annotating (list (completing-read "Which notes file should we open? "
                                                               notes-files-annotating nil t))))
 


### PR DESCRIPTION
When a note only exists in one file, `org-noter` shouldn't prompt the user to select that file. However, in some cases the code would find a file twice, causing n unnecessary prompt. This fix de-dups the list.

My config is:

```
(setq org-noter-auto-save-last-location t
        org-noter-notes-search-path '("~/Sync")
        org-noter-default-notes-file-names '("~/Sync/pdf_notes.org"))
```