### PR TITLE
org-pdftools integration

### DIFF
--- a/org-noter.el
+++ b/org-noter.el
@@ -891,9 +891,7 @@ When INCLUDE-ROOT is non-nil, the root heading is also eligible to be returned."
                     (stringp location))
                (progn
                  (string-match
-
                   "\\(.*\\)::\\([0-9]*\\)\\(\\+\\+\\)?\\([[0-9]\\.*[0-9]*\\)?\\(;;\\|\\$\\$\\)?\\(.*\\)?"
-                  "\\(.*\\)::\\([0-9]*\\)\\+\\+\\([[0-9]\\.*[0-9]*\\);;\\(.*\\)"
                   location)
                  (let ((path (match-string 1 location))
                        (page (match-string 2 location))
@@ -901,35 +899,33 @@ When INCLUDE-ROOT is non-nil, the root heading is also eligible to be returned."
                        annot-id search-string)
                    ;; (org-open-file path 1)
                    (cond ((string-equal
-                           (match-string 5 link)
+                           (match-string 5 location)
                            ";;")
                           (setq annot-id
-                                (match-string 6 link)))
+                                (match-string 6 location)))
                          ((string-equal
-                           (match-string 5 link)
+                           (match-string 5 location)
                            "$$")
                           (setq search-string
                                 (replace-regexp-in-string
                                  "%20"
                                  " "
-                                 (match-string 6 link)))))
+                                 (match-string 6 location)))))
                    (when page
-                       (pdf-view-goto-page (string-to-number page)))
+                     (setq page (string-to-number page))
+                     (pdf-view-goto-page page))
                    (when height
                        (image-set-window-vscroll
                         (round
                          (/
                           (*
-                           string-to-number height
+                           (string-to-number height)
                            (cdr (pdf-view-image-size)))
                           (frame-char-height)))))
                    (when annot-id
                        (pdf-annot-show-annotation
                         (pdf-info-getannot annot-id)
-                        t))
-                   (when search-string
-                     (isearch-mode t)
-                     (isearch-yank-string search-string))))
+                        t))))
              (pdf-view-goto-page (car location))
              ;; NOTE(nox): This timer is needed because the tooltip may introduce a delay,
              ;; so syncing multiple pages was slow

--- a/org-noter.el
+++ b/org-noter.el
@@ -925,7 +925,10 @@ When INCLUDE-ROOT is non-nil, the root heading is also eligible to be returned."
                    (when annot-id
                        (pdf-annot-show-annotation
                         (pdf-info-getannot annot-id)
-                        t))))
+                        t))
+                   (when search-string
+                     (isearch-mode t)
+                     (isearch-yank-string search-string))))
              (pdf-view-goto-page (car location))
              ;; NOTE(nox): This timer is needed because the tooltip may introduce a delay,
              ;; so syncing multiple pages was slow

--- a/org-noter.el
+++ b/org-noter.el
@@ -1909,7 +1909,7 @@ defines if the text should be inserted inside the note."
                      (org-pdftools-markup-pointer-color org-noter-markup-pointer-color)
                      (org-pdftools-markup-pointer-opacity org-noter-markup-pointer-opacity)
                      (org-pdftools-markup-pointer-function org-noter-markup-pointer-function))
-                 (org-pdftools-get-link))))
+                 (org-pdftools-get-link t))))
           (location
            (if location-link
                (org-noter--location-link-to-cons

--- a/org-noter.el
+++ b/org-noter.el
@@ -2219,21 +2219,32 @@ As such, it will only work when the notes window exists."
 
 (defun org-noter-jump-to-note (a)
   "Jump from a PDF annotation A to the corresponding org heading."
-  (interactive (list (with-selected-window (org-noter--get-doc-window)
+  (interactive (list
+                (with-selected-window
+                    (org-noter--get-doc-window)
                   (pdf-annot-read-annotation
                    "Left click the annotation "))))
   (org-noter--with-valid-session
-   (let ((id (symbol-name (pdf-annot-get-id a))))
-     (select-window (org-noter--get-notes-window))
-     (condition-case-unless-debug nil
+   (pdf-annot-show-annotation a t)
+   (let ((id (symbol-name
+              (pdf-annot-get-id a))))
+     (select-window
+      (org-noter--get-notes-window))
+     (condition-case-unless-debug
+         nil
          (progn
            (goto-char
-            (cdr
-             (org-id-find-id-in-file
-              id
-              buffer-file-name)))
-           t)
-       (error nil)))))
+            (cdr (org-id-find-id-in-file
+                  (if org-noter-use-unique-org-id
+                      (concat
+                       (org-noter--session-property-text
+                        session)
+                       "-"
+                       id)
+                    id)
+                  buffer-file-name))))
+       (error nil))
+     t)))
 
 
 (define-minor-mode org-noter-doc-mode

--- a/org-noter.el
+++ b/org-noter.el
@@ -1098,7 +1098,7 @@ document property) will be opened."
    ((eq (aref view 0) 'paged)
     (if (org-noter--location-link-p note-property)
         (setq note-property (org-noter--location-link-to-cons note-property))
-      (setq note-property (read-from-string note-property)))
+      (setq note-property (car (read-from-string note-property))))
     (let ((note-page (car note-property))
           (view-page (aref view 1)))
       (cond ((< note-page view-page) 'before)

--- a/org-noter.el
+++ b/org-noter.el
@@ -1604,14 +1604,12 @@ want to kill."
                                (cdr location)
                              0.0))
                    (pos `(0 . ,(round
-                                (/
-                                 (*
-                                  (cdr (with-current-buffer
-                                           (org-noter--session-doc-buffer
-                                            session)
-                                         (pdf-view-image-size)))
-                                  height)
-                                 (frame-char-height)))))
+                                (*
+                                 (cdr (with-current-buffer
+                                          (org-noter--session-doc-buffer
+                                           session)
+                                        (pdf-view-image-size)))
+                                 height))))
                    (annot-id (symbol-name
                               (pdf-annot-get-id
                                (save-excursion

--- a/org-noter.el
+++ b/org-noter.el
@@ -931,8 +931,8 @@ When INCLUDE-ROOT is non-nil, the root heading is also eligible to be returned."
        ;; everything and would run org-noter--nov-scroll-handler.
        (redisplay)))))
 
-(defun org-noter--location-link-p (locaiton)
-  (and lcoation
+(defun org-noter--location-link-p (location)
+  (and location
        (stringp location)
        (string-prefix-p "pdftools:" location)))
 
@@ -1097,7 +1097,8 @@ document property) will be opened."
   (cond
    ((eq (aref view 0) 'paged)
     (if (org-noter--location-link-p note-property)
-        (setq note-property (org-noter--location-link-to-cons note-property)))
+        (setq note-property (org-noter--location-link-to-cons note-property))
+      (setq note-property (read-from-string note-property)))
     (let ((note-page (car note-property))
           (view-page (aref view 1)))
       (cond ((< note-page view-page) 'before)

--- a/org-noter.el
+++ b/org-noter.el
@@ -2224,6 +2224,8 @@ As such, it will only work when the notes window exists."
                     (org-noter--get-doc-window)
                   (pdf-annot-read-annotation
                    "Left click the annotation "))))
+  (when (not org-noter-use-org-id)
+    "You have to enable `org-noter-use-org-id'!")
   (org-noter--with-valid-session
    (pdf-annot-show-annotation a t)
    (let ((id (symbol-name
@@ -2233,6 +2235,7 @@ As such, it will only work when the notes window exists."
      (condition-case-unless-debug
          nil
          (progn
+           (require 'org-id)
            (goto-char
             (cdr (org-id-find-id-in-file
                   (if org-noter-use-unique-org-id

--- a/org-noter.el
+++ b/org-noter.el
@@ -1933,7 +1933,7 @@ defines if the text should be inserted inside the note."
 
            (cond
             ;; NOTE(nox): Both precise and without questions will create new notes
-            (precise-location
+            ((or org-noter-use-pdftools-link-location precise-location)
              (setq default (and selected-text (replace-regexp-in-string "\n" " " selected-text))))
             (org-noter-insert-note-no-questions)
             (t

--- a/org-noter.el
+++ b/org-noter.el
@@ -143,6 +143,11 @@ To use this, org-noter-use-org-id has to be t."
   :group 'org-noter
   :type 'boolean)
 
+(defcustom org-noter-use-unique-org-id t
+  "When non-nil, an org-id is generated for each heading for linking with PDF annotations and record entry parents."
+  :group 'org-noter
+  :type 'boolean)
+
 (defcustom org-noter-notes-window-behavior '(start scroll)
   "This setting specifies in what situations the notes window should be created.
 
@@ -1633,7 +1638,12 @@ want to kill."
                 (org-entry-put
                  nil
                  "ID"
-                 annot-id))
+                 (if org-noter-use-unique-org-id
+                     (concat
+                      document-property
+                      "-"
+                      annot-id)
+                   annot-id)))
               (when org-noter-export-to-pdf
                 (let* ((content (if (and (> (org-current-level) 2)
                                          org-noter-export-to-pdf-with-structure)
@@ -2005,7 +2015,13 @@ defines if the text should be inserted inside the note."
                (when (string-match ".*;;\\(.*\\)" location-link)
                  (let ((id (match-string 1 location-link)))
                    (if org-noter-use-org-id
-                       (org-entry-put nil "ID" id))))
+                       (org-entry-put nil "ID"
+                                      (if org-noter-use-unique-org-id
+                                          (concat
+                                           (org-noter--session-property-text session)
+                                           "-"
+                                           id)
+                                          id)))))
                (when org-noter-doc-property-in-notes
                  (org-entry-put nil org-noter-property-doc-file (org-noter--session-property-text session))
                  (org-entry-put nil org-noter--property-auto-save-last-location "nil"))

--- a/org-noter.el
+++ b/org-noter.el
@@ -2002,6 +2002,10 @@ defines if the text should be inserted inside the note."
                               (if org-noter-use-pdftools-link-location
                                   location-link
                                 (org-noter--pretty-print-location location)))
+               (when (string-match ".*;;\\(.*\\)" location-link)
+                 (let ((id (match-string 1 location-link)))
+                   (if org-noter-use-org-id
+                       (org-entry-put nil "ID" id))))
                (when org-noter-doc-property-in-notes
                  (org-entry-put nil org-noter-property-doc-file (org-noter--session-property-text session))
                  (org-entry-put nil org-noter--property-auto-save-last-location "nil"))
@@ -2196,6 +2200,25 @@ As such, it will only work when the notes window exists."
            (org-noter--focus-notes-region (org-noter--make-view-info-for-single-note next)))
        (error "There is no next note"))))
   (select-window (org-noter--get-doc-window)))
+
+(defun org-noter-jump-to-note (a)
+  "Jump from a PDF annotation A to the corresponding org heading."
+  (interactive (list (with-selected-window (org-noter--get-doc-window)
+                  (pdf-annot-read-annotation
+                   "Left click the annotation "))))
+  (org-noter--with-valid-session
+   (let ((id (symbol-name (pdf-annot-get-id a))))
+     (select-window (org-noter--get-notes-window))
+     (condition-case-unless-debug nil
+         (progn
+           (goto-char
+            (cdr
+             (org-id-find-id-in-file
+              id
+              buffer-file-name)))
+           t)
+       (error nil)))))
+
 
 (define-minor-mode org-noter-doc-mode
   "Minor mode for the document buffer.


### PR DESCRIPTION
This PR integrates org-noter with org-pdftools. By using org-pdftools links as the new format to record the location, it's now possible to specify the exact annotation you want to link to.

See https://github.com/fuxialexander/org-pdftools for more detail.
DEMO: https://www.youtube.com/watch?v=lCc3UoQku-E

Most commands now work just fine, including a new command to convert old format notes to the new format: `org-noter-conver-old-notes` and a command to jump from pdf-annot to specific heading `org-noter-jump-to-note`.
- `org-noter-create-skeleton` now works fine

Things haven't finished yet:
- ~~org-noter-create-skeleton~~
- A pdf annotation -> org importer function. Possibly called when session starts to ensure one-to-one sync between org and pdf annotations.
- A org->pdf annotation export function. Possibly called at session kill to ensure one-to-one sync between org and pdf annotations.