### PR TITLE
Fix location autosave when using org-pdftools integration

### DIFF
--- a/org-noter.el
+++ b/org-noter.el
@@ -1320,7 +1320,7 @@ With a prefix ARG, remove start location."
   (org-noter--with-valid-session
    (let ((inhibit-read-only t)
          (ast (org-noter--parse-root))
-         (location (org-noter--doc-approx-location 'interactive)))
+         (location (org-noter--doc-approx-location (when (called-interactively-p 'any) 'interactive))))
      (with-current-buffer (org-noter--session-notes-buffer session)
        (org-with-wide-buffer
         (goto-char (org-element-property :begin ast))

--- a/org-noter.el
+++ b/org-noter.el
@@ -38,6 +38,7 @@
 (require 'org)
 (require 'org-element)
 (require 'cl-lib)
+(require 'org-roam-bibtex nil t)
 
 (declare-function doc-view-goto-page "doc-view")
 (declare-function image-display-size "image-mode")
@@ -57,6 +58,7 @@
 (declare-function pdf-view-active-region-text "ext:pdf-view")
 (declare-function pdf-view-goto-page "ext:pdf-view")
 (declare-function pdf-view-mode "ext:pdf-view")
+(declare-function orb-find-note-file "ext:orb-utils")
 (defvar nov-documents-index)
 (defvar nov-file-name)
 
@@ -2206,6 +2208,11 @@ notes file, even if it finds one."
               (unless (member file notes-files) (push file notes-files))
               (when (org-noter--check-if-document-is-annotated-on-file document-path file)
                 (push file notes-files-annotating)))))
+
+        (when (fboundp #'orb-find-note-file)
+          (when-let ((file-name (orb-find-note-file document-base)))
+            (push file-name notes-files)
+            (push file-name notes-files-annotating)))
 
         (setq search-names (nreverse search-names))
 


### PR DESCRIPTION
Hi!

I'm trying to get `org-noter-integration.el` working. Core functionality seems to be OK, but I've encountered an issue when running with `org-noter-auto-save-last-location` enabled. It results in `org-noter-pdftools--doc-approx-location` being called with `'interactive` argument on every page change. That in turn activates interactive branch ("Do you want to create a free pointer annotation for the link?") in `org-pdftools-get-link`. This patch prevents that by changing `org-noter-set-start-location` so that `'interactive` is passed to `org-noter-pdftools--doc-approx-location` only when directly called by user, not from `org-noter--doc-location-change-handler`.