### PR TITLE
org-noter-kill-frame-at-session-end : remove edge case

### DIFF
--- a/org-noter.el
+++ b/org-noter.el
@@ -1568,6 +1568,7 @@ want to kill."
 
       (with-current-buffer doc-buffer
         (remove-hook 'kill-buffer-hook 'org-noter--handle-kill-buffer t))
+      (if (not org-noter-kill-frame-at-session-end) (set-window-dedicated-p (get-buffer-window doc-buffer) nil))
       (kill-buffer doc-buffer)
 
       (when (frame-live-p frame)


### PR DESCRIPTION
Solves #125 by setting the window as not dedicated.

Credit goes to @codetrick.