### PR TITLE
fix: save point before making frame in case it moves.

### DIFF
--- a/org-noter.el
+++ b/org-noter.el
@@ -365,6 +365,11 @@ The title used will be the default one."
            (or (buffer-base-buffer) (current-buffer))
            (generate-new-buffer-name (concat "Notes of " display-name)) t))
 
+         ;; NOTE(2e0byo): `make-frame' can modify point, possibly by calling a
+         ;; hook.  Thus we save the point before making the frame in case it
+         ;; moves.
+         (starting-point (point))
+
          (session
           (make-org-noter--session
            :id (org-noter--get-new-id)
@@ -392,8 +397,7 @@ The title used will be the default one."
            :closest-tipping-point (org-noter--property-or-default closest-tipping-point)
            :modified-tick -1))
 
-         (target-location org-noter--start-location-override)
-         (starting-point (point)))
+         (target-location org-noter--start-location-override))
 
     (add-hook 'delete-frame-functions 'org-noter--handle-delete-frame)
     (push session org-noter--sessions)


### PR DESCRIPTION
`org-noter` stopped working for me recently and I traced it to `create-frame` modifying `point` (specifically, moving it to the end of the buffer).  This causes a subsequent call to `org-noter--parse-root` to fail since it's on the the wrong part of the buffer.

I don't see anything in the release notes about `make-frame` no longer being idempotent.  It could be something happening in a hook this end, but I've not got the time to look into it at the moment.  But in any case I can't see any harm in setting `current-pos` *before* calling `make-frame`, which ensures this works even on potentially broken systems.

NB I realise this repository is basically abandoned, but there doesn't seem to be a definitive fork so I'm dropping it here in case anyone else has this problem.