### PR TITLE
Consider `org-noter-separate-notes-from-heading` and `org-noter-max-short-selected-text-length` in `org-noter-pdftools-create-skeleton`

### DIFF
--- a/org-noter.el
+++ b/org-noter.el
@@ -1733,10 +1733,16 @@ Only available with PDF Tools."
 
                (when (car contents)
                  (org-noter--insert-heading (1+ level) "Contents")
-                 (insert (car contents)))
+                 (let* ((text (car contents))
+                        (len (length text)))
+                   (insert (if org-noter-separate-notes-from-heading "\n" "")
+                           (if (<= len org-noter-max-short-selected-text-length)
+                               text
+                             (concat "#+BEGIN_QUOTE\n" text "\n#+END_QUOTE")))))
                (when (cdr contents)
                  (org-noter--insert-heading (1+ level) "Comment")
-                 (insert (cdr contents)))))
+                 (insert (if org-noter-separate-notes-from-heading "\n" "")
+                         (cdr contents)))))
 
            (setq ast (org-noter--parse-root))
            (org-noter--narrow-to-root ast)


### PR DESCRIPTION
This pull request modifies the inserted text from `org-noter-pdftools-create-skeleton` such that the values of `org-noter-separate-notes-from-heading` and `org-noter-max-short-selected-text-length` are taken into account.

In particular, if `org-noter-separate-notes-from-heading` is non-nil, then a newline separates the inserted headline contents from their headlines, and if the inserted annotated text (not the comment, but the text annotated in the PDF) is more than `org-noter-max-short-selected-text-length`, then that text is put into an org quote block.